### PR TITLE
Backend function now only gets called on init hook.

### DIFF
--- a/src/plugin.php
+++ b/src/plugin.php
@@ -21,7 +21,7 @@ class Roots_Rewrites {
     define('THEME_PATH',            RELATIVE_CONTENT_PATH . '/themes/' . THEME_NAME . '/assets');
 
     if (is_admin()) {
-      $this->backend();
+      add_action('admin_init', array($this, 'backend'));
     } else {
       add_action('after_setup_theme', array($this, 'frontend'));
     }
@@ -41,7 +41,7 @@ class Roots_Rewrites {
     $this->add_filters($tags, array($this, 'roots_clean_urls'));
   }
 
-  private function backend() {
+  public function backend() {
     if ($this->disabled()) { return; }
     global $wp_rewrite;
 


### PR DESCRIPTION
A small fix to prevent the plugin from being loaded too early.
It was giving errors:

Notice: Use of undefined constant TEMPLATEPATH - assumed 'TEMPLATEPATH' in /wp-includes/theme.php on line 131
Notice: Use of undefined constant STYLESHEETPATH - assumed 'STYLESHEETPATH' in /wp-includes/theme.php on line 131
